### PR TITLE
Use of the snap_common folder for runtime

### DIFF
--- a/bin/dockerd-wrapper
+++ b/bin/dockerd-wrapper
@@ -35,13 +35,13 @@ trap - EXIT
 mkdir -p \
 	"$SNAP_DATA/run" \
 	"$SNAP_DATA/run/docker" \
-	"$SNAP_DATA/var-lib-docker"
+	"$SNAP_COMMON/var-lib-docker"
 set -- \
 	--debug \
 	--log-level=debug \
 	\
 	--exec-root="$SNAP_DATA/run/docker" \
-	--graph="$SNAP_DATA/var-lib-docker" \
+	--graph="$SNAP_COMMON/var-lib-docker" \
 	--pidfile="$SNAP_DATA/run/docker.pid" \
 	\
 	"$@"


### PR DESCRIPTION
Use the snap_common folder for the runtime folder, avoiding having to copy images and containers around on updates.

These are the tests done to make sure it works:

 * The first time you upgrade from a snap that had the images/containers in current, rather than common you lose those images and containers, so we should make these changes as soon as possible (before the snap goes to stable)

 * Once you have a docker snap that stores everything to common this is the testing I have done:
  - Upgrading a docker snap shuts down any running container, but this is what happens in docker in general
  - If you have set up your container to autorestart, it does so correctly after upgrade
  - After upgrade "docker ps -a" will show your previous containers correctly
  - After upgrade "docker images" show your previous images correctly
