### PR TITLE
Add apt key for launchpad snappy repositories

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -64,6 +64,7 @@ parts:
     shell: bash
     shell-flags: ['-eux', '-o', 'pipefail']
     shell-command: |
+      apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys F1831DDAFC42E99D
       add-apt-repository ppa:jonathonf/golang-1.7
       apt update
       apt remove -y golang-go


### PR DESCRIPTION
Launchpad does not provide this key in the snappy build context.

See also:
http://askubuntu.com/questions/827996/error-in-building-snap-package-on-launchpad
https://bugs.launchpad.net/ubuntu/+source/snapcraft/+bug/1621382