### PR TITLE
Drop extra user feature and use the root user to run docker.

### DIFF
--- a/bin/dockerd-wrapper
+++ b/bin/dockerd-wrapper
@@ -14,7 +14,7 @@ workaround_lp1626019() {
 workaround_lp1606510() {
     name=`grep "DISTRIB_DESCRIPTION" /etc/lsb-release | cut -d '=' -f2 | sed 's/"*"//g'`
     if [ "$name" = "Ubuntu Core 16" ]; then
-        default_socket_group=docker-snap
+        default_socket_group=root
     fi
 }
 

--- a/bin/help
+++ b/bin/help
@@ -15,13 +15,8 @@ echo -e "\nOn Ubuntu Core 16, after installing the docker snap from store,"
 echo -e "Firstly, you need to connect the home interfaces as it's not auto-connected by default."
 echo -e "\tsudo snap connect docker:home :home"
 
-echo -e "\nSecondly, add a user and group \"docker-snap\" for the first installation"
-echo -e "and reload the snap "
-echo -e "\tsudo useradd --system --extrausers --create-home docker-snap"
-echo -e "\tsudo snap disable docker"
-echo -e "\tsudo snap enable  docker"
-
-echo -e "\nThirdly, please switch to newly created docker-snap user."
+echo -e "\nSecondly, please switch to root user."
 echo -e "\tsudo -s"
-echo -e "\tsu docker-snap"
-echo -e "\tcd $"HOME""
+echo -e "\tcd /root"
+
+echo -e "\nThen have fun with docker in snappy."

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,7 +56,6 @@ parts:
       install -d "$SNAPCRAFT_PART_INSTALL/bin"
       install -t "$SNAPCRAFT_PART_INSTALL/bin" "$SNAPDIR"/bin/*
     stage-packages:
-      #- adduser
       - mount
 
   ppa:


### PR DESCRIPTION
Adding an extra user requires more manual setup. To simplify it,
we run docker as the root user.