### PR TITLE
Build golang1.7 from source.

### DIFF
--- a/bin/dockerd-wrapper
+++ b/bin/dockerd-wrapper
@@ -72,4 +72,4 @@ workaround_lp1626019
 
 workaround_lp1606510
 
-exec docker daemon -G $default_socket_group "$@"
+exec dockerd -G $default_socket_group "$@"

--- a/snap/plugins/x-gobuild.py
+++ b/snap/plugins/x-gobuild.py
@@ -1,0 +1,103 @@
+import os
+import subprocess
+import sys
+
+import snapcraft
+
+
+def list_executables(dir):
+    """Return a list of the executable files under `dir`."""
+    output = subprocess.check_output(
+        ['find', dir, '-executable', '-type', 'f'])
+    r = set()
+    for line in output.splitlines():
+        r.add(line.decode(sys.getfilesystemencoding()))
+    return r
+
+
+def is_dynamic_executable(path):
+    """Is `path` a dynamic executable?"""
+    from elftools.elf.elffile import ELFFile
+    from elftools.common.exceptions import ELFError
+    # This way of answering the question is perhaps a bit OTT. But it works.
+    try:
+        e = ELFFile(open(path, 'rb'))
+        return 'PT_DYNAMIC' in [s.header.p_type for s in e.iter_segments()]
+    except ELFError as e:
+        print("ELFFile({}) failed {}".format(path, e))
+        return False
+
+
+class XGobuildPlugin(snapcraft.BasePlugin):
+    def build(self):
+        env = os.environ.copy()
+
+        # Bootstrap with the go that is on the PATH.
+        goroot_bootstrap = subprocess.check_output(['go', 'env', 'GOROOT'])
+        env['GOROOT_BOOTSTRAP'] = goroot_bootstrap.decode(sys.getfilesystemencoding()).rstrip('\n')
+        # Set GOROOT_FINAL to something that should work (we don't
+        # know the actual GOROOT until the package is uploaded to the
+        # store, sadly).
+        env['GOROOT_FINAL'] = '/snap/go/current'
+        # But set GOROOT for now so that things continue to work.
+        env['GOROOT'] = self.builddir
+        arch = os.popen('dpkg --print-architecture').read().strip()
+        if arch == 'amd64' or arch == 'i386':
+            # Mystical incantation so that the C object files that end
+            # up in e.g. runtime/cgo.a can be processed by the system
+            # linker on trusty.
+            env['CGO_CFLAGS'] = "-Wa,-mrelax-relocations=no"
+
+        # All dynamic executables in a classic snap must be linked
+        # with special flags.  The Go linker does not support
+        # equivalents of all these flags, so we need to link all
+        # dynamic executables with the system linker. Unfortunately
+        # GO_LDFLAGS='-linkmode=external' ./make.bash doesn't actually
+        # work correctly on all platforms (the cgo stuff does not get
+        # built early enough) so we bootstrap normally then relink
+        # any dynamic binaries with the right flags.
+
+        binaries_before = list_executables(self.builddir)
+        self.run(['./make.bash'], cwd=os.path.join(self.builddir, 'src'), env=env)
+        self.run(['rm', '-rf', 'pkg/bootstrap'], cwd=self.builddir)
+        new_binaries = list_executables(self.builddir) - binaries_before
+
+        # For extra fun, the special flags we need to link with are
+        # not easily available from here -- they are exported as
+        # $LDFLAGS inside self.run. But the go tool doesn't care about
+        # $LDFLAGS, so we create a wrapper that does and tell the go
+        # tool to invoke that instead.
+
+        builtgo = os.path.join(self.builddir, 'bin', 'go')
+        mycc = os.path.join(self.builddir, 'mycc')
+        with open(mycc, 'w') as script:
+            os.chmod(script.fileno(), 0o755)
+            script.write('#!/bin/bash\n')
+            script.write('set -ex\n')
+            script.write('exec gcc $LDFLAGS "$@"\n')
+
+        try:
+            ldflags = '-linkmode=external -extld={}'.format(mycc)
+            # Find any newly created dynamic binaries and rebuild them.
+            for binary in new_binaries:
+                if not is_dynamic_executable(binary):
+                    continue
+                bn = os.path.basename(binary)
+                pkg = 'cmd/' + bn
+                self.run(
+                    [builtgo, 'build', '-v', '-ldflags', ldflags, pkg],
+                    cwd=self.builddir, env=env)
+                os.rename(os.path.join(self.builddir, bn), binary)
+        finally:
+            # Remove our gcc wrapper.
+            os.unlink(mycc)
+
+        # Just ship the whole tree.
+        self.run(['rsync', '-a', '--exclude', '.git', self.builddir + '/', self.installdir])
+
+        # And finally, create a wrapper that sets $GOROOT based on $SNAP.
+        with open(os.path.join(self.installdir, 'gowrapper'), 'w') as script:
+            os.chmod(script.fileno(), 0o755)
+            script.write('#!/bin/bash\n')
+            script.write('export GOROOT="$SNAP"\n')
+            script.write('exec $SNAP/bin/go "$@"\n')

--- a/snap/plugins/x-gobuild.yaml
+++ b/snap/plugins/x-gobuild.yaml
@@ -1,0 +1,6 @@
+options:
+    source:
+        required: true
+    source-type:
+    source-tag:
+    source-branch:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,17 +59,18 @@ parts:
     stage-packages:
       - mount
 
-  ppa:
-    plugin: shell
-    shell: bash
-    shell-flags: ['-ex']
-    shell-command: |
-      apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys F1831DDAFC42E99D
-      add-apt-repository ppa:jonathonf/golang-1.7
-      apt update
-      apt install -y golang-1.7
+  go:
+    plugin: gobuild
+    source: https://storage.googleapis.com/golang/go1.7.5.src.tar.gz
+    source-type: tar
+    snap:
+      - -*
     build-packages:
-      - software-properties-common
+      - golang-go
+      - rsync
+      - build-essential
+      - netbase
+      - python3-pyelftools
 
   docker:
     plugin: shell
@@ -78,7 +79,7 @@ parts:
     shell: bash
     shell-flags: ['-eux', '-o', 'pipefail']
     shell-command: |
-      export GOROOT=/usr/lib/go-1.7
+      export GOROOT="$SNAPDIR/parts/go/install"
       export PATH="$GOROOT/bin:$PATH"
       go version
 
@@ -99,7 +100,7 @@ parts:
       install -T "$(readlink -f "$clientBin")" "$SNAPCRAFT_PART_INSTALL/bin/docker"
       install -T "$(readlink -f "$daemonBin")" "$SNAPCRAFT_PART_INSTALL/bin/dockerd"
     after:
-      - ppa
+      - go
     build-packages:
       - btrfs-tools
       - gcc
@@ -119,7 +120,7 @@ parts:
     shell: bash
     shell-flags: ['-ex']
     shell-command: |
-      export GOROOT=/usr/lib/go-1.7
+      export GOROOT="$SNAPDIR/parts/go/install"
       export PATH="$GOROOT/bin:$PATH"
       go version
 
@@ -134,7 +135,7 @@ parts:
       install -T bin/containerd-shim "$SNAPCRAFT_PART_INSTALL/bin/docker-containerd-shim"
       install -T bin/ctr "$SNAPCRAFT_PART_INSTALL/bin/docker-containerd-ctr"
     after:
-      - ppa
+      - go
     build-packages:
       - make
 
@@ -145,7 +146,7 @@ parts:
     shell: bash
     shell-flags: ['-ex']
     shell-command: |
-      export GOROOT=/usr/lib/go-1.7
+      export GOROOT="$SNAPDIR/parts/go/install"
       export PATH="$GOROOT/bin:$PATH"
       go version
 
@@ -158,7 +159,7 @@ parts:
       install -d "$SNAPCRAFT_PART_INSTALL/bin"
       install -T runc "$SNAPCRAFT_PART_INSTALL/bin/docker-runc"
     after:
-      - ppa
+      - go
     build-packages:
       - libapparmor-dev
       - libseccomp-dev
@@ -172,7 +173,7 @@ parts:
     shell: bash
     shell-flags: ['-ex']
     shell-command: |
-      export GOROOT=/usr/lib/go-1.7
+      export GOROOT="$SNAPDIR/parts/go/install"
       export PATH="$GOROOT/bin:$PATH"
       go version
 
@@ -190,7 +191,7 @@ parts:
       install -T bin/docker-proxy "$SNAPCRAFT_PART_INSTALL/bin/docker-proxy"
       install -T bin/dnet "$SNAPCRAFT_PART_INSTALL/bin/dnet"
     after:
-      - ppa
+      - go
     build-packages:
       - iptables
       - make


### PR DESCRIPTION
As of now, go plugin doesn't support to version option and
we're not able to specify go 1.7 as the preferred compiler to
build each docker and its components.
An open bug can be found here
https://bugs.launchpad.net/snapcraft/+bug/1616985

Meanwhile, golang1.7 deb package for the archs[armhf,arm64,ppc]
can not be found in the ppa we imported.
https://launchpad.net/~jonathonf/+archive/ubuntu/golang-1.7

So in order to release docker-snap for all archs, we have to
create custom plugin and build golang-1.7 from source as
the compiler that we're going to use to build docker snap.